### PR TITLE
change to import element

### DIFF
--- a/app/assets/html/concerto_iframe/concerto-iframe.html
+++ b/app/assets/html/concerto_iframe/concerto-iframe.html
@@ -1,0 +1,44 @@
+<!--
+The `concerto-iframe` element provides embedded content
+-->
+<dom-module id="concerto-iframe">
+  <style>
+    :host {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+    #iframe {
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+
+  <template> 
+    <iframe id="iframe" frameBorder="0"></iframe>
+  </template>
+
+  <script>
+    ConcertoIframe = Polymer({
+      is: "concerto-iframe",
+
+      behaviors: [ConcertoBehaviors.BaseContent],
+
+      properties: {
+        baseUrl: String,
+        path: {
+          type: String,
+          observer: 'pathChanged'
+        },
+        config: Object
+      },
+
+      pathChanged: function() {
+        this.$.iframe.src = this.path;
+      }
+    });
+  </script>
+</dom-module>
+<script>
+  ConcertoBehaviors.ContentFactory.registerContent("concerto-iframe", "ConcertoIframe");
+</script>

--- a/app/views/frontend/_concerto_iframe.html
+++ b/app/views/frontend/_concerto_iframe.html
@@ -1,44 +1,5 @@
-<!--
-The `concerto-iframe` element provides embedded content
--->
-<dom-module id="concerto-iframe">
-  <style>
-    :host {
-      display: block;
-      width: 100%;
-      height: 100%;
-    }
-    #iframe {
-      width: 100%;
-      height: 100%;
-    }
-  </style>
-
-  <template> 
-    <iframe id="iframe" frameBorder="0"></iframe>
-  </template>
-
-  <script>
-    ConcertoIframe = Polymer({
-      is: "concerto-iframe",
-
-      behaviors: [ConcertoBehaviors.BaseContent],
-
-      properties: {
-        baseUrl: String,
-        path: {
-          type: String,
-          observer: 'pathChanged'
-        },
-        config: Object
-      },
-
-      pathChanged: function() {
-        this.$.iframe.src = this.path;
-      }
-    });
-  </script>
-</dom-module>
-<script>
-  ConcertoBehaviors.ContentFactory.registerContent("concerto-iframe", "ConcertoIframe");
-</script>
+<% content_for :head do %>
+<!-- from concerto-iframe -->
+  <%= tag "link", rel: "import", href: asset_path("concerto_iframe/concerto-iframe.html") %>
+<!-- end from concerto-iframe -->
+<% end %>


### PR DESCRIPTION
This is related to https://github.com/concerto/concerto-frontend/issues/47 and should not be merged until that issue is closed.

I changed the polymer element from being included directly into the frontend screen to be imported because the ConcertoBehaviors were not being defined before this element was being initialized.  By moving it to an import, it is now processed after the behaviors are loaded/initialized.  

This wont work without the related branches in concerto and concerto-frontend repos.  I also had to make a similar change the to concerto-remote-video repo.